### PR TITLE
Remove timestamps from models

### DIFF
--- a/src/types/common.d.ts
+++ b/src/types/common.d.ts
@@ -21,15 +21,11 @@ interface IAuth {
 interface IUser {
     id: number;
     email: string;
-    created_at: string;
-    updated_at: string;
 }
 interface RecipeInterface {
     id: number;
     name: string;
     instructions: string;
-    created_at: string;
-    updated_at: string;
     user_id: number
 }
 
@@ -45,7 +41,5 @@ interface IAuthHook {
 interface IngredientInterface {
     id: number;
     name: string;
-    created_at: string;
-    updated_at: string;
     user_id: number
 }


### PR DESCRIPTION
I just updated the BE and is no longer sending the `created_at` and `updated_at` attributes as part of any response.

Make sure to update your BE repo to the latest master commit